### PR TITLE
Change install command to "pip install -e"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Install
 -------
 ::
 
-    $ pip install git+https://github.com/jettify/aiobotocore.git@master
+    $ pip install -e git+https://github.com/jettify/aiobotocore.git@master#egg=aiobotocore
 
 
 Basic Example


### PR DESCRIPTION
This way the github url is baked into `pip freeze`'s output so that a `pip install -r requirements.txt` will work. The other way makes aiobotocore's line in `pip freeze` just like any other pypi package, and will fail if one tries to install it.