### PR TITLE
Fixing streaming responses.

### DIFF
--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -32,6 +32,23 @@ def convert_to_response_dict(http_response, operation_model):
     return response_dict
 
 
+class ClientResponseContentProxy:
+    """Proxy object for content stream of http response"""
+
+    def __init__(self, response):
+        self.__response = response
+        self.__content = self.__response.content
+
+    def __getattr__(self, item):
+        return getattr(self.__content, item)
+
+    def __dir__(self):
+        attrs = dir(self.__content)
+        attrs.append('close')
+
+    def close(self):
+        self.__response.close()
+
 class ClientResponseProxy:
     """Proxy object for http response useful for porting from
     botocore underlying http library."""
@@ -46,7 +63,7 @@ class ClientResponseProxy:
         if item == 'content':
             return self._body
         if item == 'raw':
-            return getattr(self._impl, 'content')
+            return ClientResponseContentProxy(self._impl)
 
         return getattr(self._impl, item)
 

--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -45,6 +45,7 @@ class ClientResponseContentProxy:
     def __dir__(self):
         attrs = dir(self.__content)
         attrs.append('close')
+        return attrs
 
     def close(self):
         self.__response.close()


### PR DESCRIPTION
Closing the body stream now closes the underlying aiohttp reponse object.

This is an attempt to improve on the fix proposed in #18.  The fix in this PR does not require streaming the entire response into memory.  The FlowControlStreamReader instance coming from aiohttp is wrapped with a proxy that adds a close method ( which closes the underlying aiohttp request ) and proxies all other attributes to the FlowControlStreamReader instance.

This allows you to write code like this:
```python

resp = yield from s3.get_object(Bucket='mybucket', Key='k')
stream = resp['Body']
try:
    chunk = yield from stream.read(s)
    while len(chunk) > 0:
      ...
      chunk = yield from stream.read(s)
finally:
  stream.close()

```
