### PR TITLE
S3 keep-alive fix

### DIFF
--- a/aiobotocore/endpoint.py
+++ b/aiobotocore/endpoint.py
@@ -69,7 +69,11 @@ class AioEndpoint(Endpoint):
                          response_parser_factory=response_parser_factory)
 
         self._loop = loop or asyncio.get_event_loop()
+        
+        # AWS has a 20 second idle timeout: https://forums.aws.amazon.com/message.jspa?messageID=215367
+        # and aiohttp default timeout is 30s so we set it to something reasonable here
         self._aio_seesion = aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(loop=self._loop, keepalive_timeout=12),
             skip_auto_headers={'CONTENT-TYPE'},
             response_class=ClientResponseProxy, loop=self._loop)
 


### PR DESCRIPTION
This fixes keep-alive for S3 ClientSessions.  Per AWS the keep-alive timeout is 20s whereas the default timeout for aiohttp is 30s.  This results in cached session connections periodically failing.  This change bumps down the default connection timeout to 12s.  I will have a pending change that allows users to parameterize the TCPConnection to enable things like DNS caching.